### PR TITLE
Editor Aspect Ratio Enforcement

### DIFF
--- a/Assets/Scenes/BaseBattleScene.unity
+++ b/Assets/Scenes/BaseBattleScene.unity
@@ -168,7 +168,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1003521265
 GameObject:
@@ -181,6 +181,7 @@ GameObject:
   - component: {fileID: 1003521268}
   - component: {fileID: 1003521267}
   - component: {fileID: 1003521266}
+  - component: {fileID: 1003521269}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -216,9 +217,9 @@ Camera:
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
-    y: 0
+    y: 0.059429202
     width: 1
-    height: 1
+    height: 0.8811416
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
@@ -247,91 +248,28 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1003521265}
   m_LocalRotation: {x: 0.1464466, y: -0.8535535, z: 0.35355338, w: 0.35355338}
-  m_LocalPosition: {x: 14, y: 14.66, z: 4.72}
+  m_LocalPosition: {x: 36.1, y: 45.9, z: 26.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 45, y: -135, z: 0}
---- !u!1 &1863481730
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1863481733}
-  - component: {fileID: 1863481732}
-  - component: {fileID: 1863481734}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1863481732
+--- !u!114 &1003521269
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1863481730}
+  m_GameObject: {fileID: 1003521265}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Script: {fileID: 11500000, guid: b00984cdbc12096418148da69760a6e4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1863481733
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1863481730}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1863481734
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1863481730}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 0
-  m_CursorLockBehavior: 0
+  _previewInEditMode: 1
+  _maskColor: {r: 0, g: 0, b: 0, a: 1}
+  _aspectRatio: 1.7777778
 --- !u!1 &1869643040
 GameObject:
   m_ObjectHideFlags: 0
@@ -392,7 +330,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &45630488289487217
 PrefabInstance:
@@ -496,11 +434,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_Pivot.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_Pivot.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_RootOrder
@@ -524,11 +462,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 1920.0001
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 1080
+      objectReference: {fileID: 0}
+    - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.022222225
+      objectReference: {fileID: 0}
+    - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.022222225
+      objectReference: {fileID: 0}
+    - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.022222225
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalPosition.x
@@ -540,31 +490,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 9.9
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.35355338
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: 0.1464466
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0.8535535
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.35355338
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 19.1
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: 21.9
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -577,6 +527,18 @@ PrefabInstance:
     - target: {fileID: 1430911598449506131, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1430911598449506132, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1003521267}
+    - target: {fileID: 1430911598449506132, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_RenderMode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1430911598449506133, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1430911598449506135, guid: 325d938f9cfe47548a0b0b869cc850ea, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/BaseBattleScene.unity
+++ b/Assets/Scenes/BaseBattleScene.unity
@@ -216,10 +216,10 @@ Camera:
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
-    x: 0
-    y: 0.059429202
-    width: 1
-    height: 0.8811416
+    x: -0.056318678
+    y: 0
+    width: 1.1126374
+    height: 1
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60

--- a/Assets/Scripts/Editor/AspectRatioEnforcerEditor.cs
+++ b/Assets/Scripts/Editor/AspectRatioEnforcerEditor.cs
@@ -1,0 +1,69 @@
+using Jrpg.Runtime.Utilities;
+using UnityEditor;
+using UnityEngine;
+
+namespace Jrpg.Editor
+{
+    /// <summary>
+    /// Aspect Ratio enforcement scripts were adopted from the following repo:
+    /// <a href="https://github.com/huchi57/AspectRatioEnforcer">huchi57/AspectRationEnforcer</a>
+    /// </summary>
+    [CustomEditor(typeof(AspectRatioEnforcer))]
+    public class AspectRatioEnforcerEditor : UnityEditor.Editor
+    {
+        private const float _16to9 = 16f / 9f;
+        private const float _16to10 = 16f / 10f;
+        private const float _21to9 = 21f / 9f;
+        private const float _4to3 = 4f / 3f;
+        private const float _5to4 = 5f / 4f;
+
+        private SerializedProperty _aspectRatio = default;
+
+        private SerializedProperty AspectRatio
+        {
+            get
+            {
+                if (_aspectRatio == null)
+                {
+                    _aspectRatio = serializedObject.FindProperty(nameof(_aspectRatio));
+                }
+                return _aspectRatio;
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            base.OnInspectorGUI();
+            GUILayout.Space(10);
+            GUILayout.Label("Quick Set from Presets:");
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button("16:9"))
+            {
+                AspectRatio.floatValue = _16to9;
+            }
+            if (GUILayout.Button("16:10"))
+            {
+                AspectRatio.floatValue = _16to10;
+            }
+            if (GUILayout.Button("21:9"))
+            {
+                AspectRatio.floatValue = _21to9;
+            }
+            if (GUILayout.Button("4:3"))
+            {
+                AspectRatio.floatValue = _4to3;
+            }
+            if (GUILayout.Button("5:4"))
+            {
+                AspectRatio.floatValue = _5to4;
+            }
+            if (GUILayout.Button("1:1"))
+            {
+                AspectRatio.floatValue = 1;
+            }
+            GUILayout.EndHorizontal();
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Scripts/Editor/AspectRatioEnforcerEditor.cs.meta
+++ b/Assets/Scripts/Editor/AspectRatioEnforcerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 241c97f7e859e3c41be8b32b8f83a463
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/Utilities/AspectRatioEnforcer.cs
+++ b/Assets/Scripts/Runtime/Utilities/AspectRatioEnforcer.cs
@@ -1,0 +1,168 @@
+using UnityEngine;
+
+namespace Jrpg.Runtime.Utilities
+{
+    /// <summary>
+    /// Aspect Ratio enforcement scripts were adopted from the following repo:
+    /// <a href="https://github.com/huchi57/AspectRatioEnforcer">huchi57/AspectRationEnforcer</a>
+    /// </summary>
+    [ExecuteInEditMode]
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Camera))]
+    public class AspectRatioEnforcer : MonoBehaviour
+    {
+        private class DisplayMask
+        {
+            private Rect _mask1 = new Rect();
+            private Rect _mask2 = new Rect();
+            private Rect _viewport = new Rect();
+
+            public Rect Mask1 => _mask1;
+            public Rect Mask2 => _mask2;
+            public Rect Viewport => _viewport;
+
+            public void SetLetterbox(float viewportHeight, float maskHeight, float viewportIncet)
+            {
+                _mask1.Set(0, 0, Screen.width, maskHeight);
+                _mask2.Set(0, maskHeight + viewportHeight, Screen.width, maskHeight);
+                _viewport.Set(0, viewportIncet / 2, 1, 1 - viewportIncet);
+            }
+
+            public void SetPillarbox(float viewportWidth, float maskWidth, float viewportIncet)
+            {
+                _mask1.Set(0, 0, maskWidth, Screen.height);
+                _mask2.Set(maskWidth + viewportWidth, 0, maskWidth, Screen.height);
+                _viewport.Set(viewportIncet / 2, 0, 1 - viewportIncet, 1);
+            }
+
+            public void ClearBox()
+            {
+                _mask1 = Rect.zero;
+                _mask2 = Rect.zero;
+                _viewport.Set(0, 0, 1, 1);
+            }
+        }
+
+        [SerializeField] private bool _previewInEditMode = true;
+        [SerializeField] private Color _maskColor = Color.black;
+        [SerializeField, Min(0)] private float _aspectRatio = 16f / 9f;
+
+        private static Texture2D _maskTexture = null;
+        private static GUIStyle _style = null;
+        private static Color _cacheMaskColor = default;
+        private Camera _camera = null;
+        private DisplayMask _mask = null;
+
+        public bool PreviewInEditMode
+        {
+            get => _previewInEditMode;
+            set => _previewInEditMode = value;
+        }
+
+        public Color MaskColor
+        {
+            get => _maskColor;
+            set => _maskColor = value;
+        }
+
+        public float AspectRatio
+        {
+            get => _aspectRatio;
+            set => _aspectRatio = value < 0f ? 0f : value;
+        }
+
+        private float ScreenRatio => Screen.width / (float)Screen.height;
+        private float ViewportInset => 1f - (ScreenRatio / AspectRatio);
+
+        private DisplayMask Mask
+        {
+            get
+            {
+                if (_mask == null)
+                {
+                    _mask = new DisplayMask();
+                }
+                return _mask;
+            }
+        }
+
+        private void DrawMask()
+        {
+            if (_maskTexture == null)
+            {
+                _maskTexture = new Texture2D(1, 1);
+                UpdateMaskColor(_maskColor);
+            }
+
+            if (_style == null)
+            {
+                _style = new GUIStyle();
+            }
+
+            if (_cacheMaskColor != _maskColor)
+            {
+                UpdateMaskColor(_maskColor);
+            }
+
+            _style.normal.background = _maskTexture;
+
+            GUI.Box(Mask.Mask1, GUIContent.none, _style);
+            GUI.Box(Mask.Mask2, GUIContent.none, _style);
+            _camera.rect = Mask.Viewport;
+        }
+
+        private void ResetCamera()
+        {
+            Mask.ClearBox();
+            _camera.rect = Mask.Viewport;
+        }
+
+        private void UpdateMaskColor(Color color)
+        {
+            _cacheMaskColor = color;
+            _maskTexture.SetPixel(0, 0, color);
+            _maskTexture.Apply();
+        }
+
+        private void OnGUI()
+        {
+            if (_previewInEditMode || Application.isPlaying)
+            {
+                if (_aspectRatio > ScreenRatio)
+                {
+                    float viewportHeight = _aspectRatio <= 0 ? Screen.height : Screen.width / _aspectRatio;
+                    float maskHeight = (Screen.height - viewportHeight) / 2;
+                    Mask.SetLetterbox(viewportHeight, maskHeight, ViewportInset);
+                }
+
+                else if (_aspectRatio < ScreenRatio)
+                {
+                    float viewportWidth = Screen.height * _aspectRatio;
+                    float maskWidth = (Screen.width - viewportWidth) / 2;
+                    Mask.SetPillarbox(viewportWidth, maskWidth, ViewportInset);
+                }
+
+                else
+                {
+                    Mask.ClearBox();
+                }
+            }
+            else
+            {
+                Mask.ClearBox();
+            }
+
+            DrawMask();
+        }
+
+        private void Awake()
+        {
+            _camera = GetComponent<Camera>();
+        }
+
+        private void OnDisable()
+        {
+            ResetCamera();
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Utilities/AspectRatioEnforcer.cs.meta
+++ b/Assets/Scripts/Runtime/Utilities/AspectRatioEnforcer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b00984cdbc12096418148da69760a6e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -88,7 +88,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -129,14 +129,13 @@ PlayerSettings:
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
   m_SupportedAspectRatios:
-    4:3: 0
-    5:4: 0
-    16:10: 0
+    4:3: 1
+    5:4: 1
+    16:10: 1
     16:9: 1
-    Others: 0
+    Others: 1
   bundleVersion: 0.1
-  preloadedAssets:
-  - {fileID: 11400000, guid: 3458cde459467494abc2ba7e8b4f950e, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Changed:
- Added `AspectRatioEnforcer` and `AspectRatioEnforcerEditor` scripts. The original version of these scripts can be seen at [huchi57/AspectRationEnforcer](https://github.com/huchi57/AspectRatioEnforcer).
- Added `AspectRatioEnforcer` script as a component of the `Main Camera` in the `BaseBattleScene` and applied a preset of `16:9`.
- Changed the `BattleScreenUI` canvas from `Screen Space - Overlay` to `World Space` due to the former not playing nice with the `AspectRatioEnforcer`. This seems to be fine for now, since the style of my game requires an `Orthographic` projection on the `Main Camera`, and allows me to put a large amount of distance between the canvases and the environment.
- Removed the `EventSystem` from the `BaseBattleScene` and migrated it into the `GameManager` prefab.

For More Info See:
#1 