### PR TITLE
Simplified `AttackPanelController` With Inheritance

### DIFF
--- a/Assets/Prefabs/Battlescreen/UI/Commands/AttackPanel.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/AttackPanel.prefab
@@ -76,16 +76,16 @@ MonoBehaviour:
   pageNumberText: {fileID: 2225511976178676351}
   optionsContainer: {fileID: 4386329965399491447}
   canvasGroup: {fileID: 7031310772184507211}
-  attackOptionPrefab: {fileID: 7020424360111604088, guid: d37dbd9f7b41cf54393063d4f5bbb265, type: 3}
-  overdriveOptionPrefab: {fileID: -1313844770527419125, guid: 39071661c63fb3c469e78f6e450676ed, type: 3}
-  attackButton: {fileID: -4256021037253564534, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  optionPrefab: {fileID: 7020424360111604088, guid: d37dbd9f7b41cf54393063d4f5bbb265, type: 3}
+  optionFaceButton: {fileID: -4256021037253564534, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   incrementOptionIndexButton: {fileID: 2228769679593563241, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   decrementOptionIndexButton: {fileID: 401235817350929183, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
-  otherButtons:
+  otherFaceButtons:
   - {fileID: 4557948942953932904, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   - {fileID: 256541589240922355, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   - {fileID: -404835749428702899, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
-  attackOptions: []
+  listOptions: []
+  overdriveOptionPrefab: {fileID: -1313844770527419125, guid: 39071661c63fb3c469e78f6e450676ed, type: 3}
 --- !u!1001 &4302823105299974583
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Runtime/Battle/Messages.cs
+++ b/Assets/Scripts/Runtime/Battle/Messages.cs
@@ -2,6 +2,7 @@ using Jrpg.Core;
 using Jrpg.Runtime.Battle.UI;
 using Jrpg.Runtime.DataClasses.Bases;
 using Jrpg.Runtime.DataClasses.Enemy;
+using Jrpg.Runtime.DataClasses.PartyData;
 
 namespace Jrpg.Runtime.Battle
 {
@@ -57,9 +58,9 @@ namespace Jrpg.Runtime.Battle
 
     internal sealed class UpdateOverdriveAchievedMessage : IMessage
     {
-        public BattlePartyMember PartyMember { get; }
+        public PartyMember PartyMember { get; }
         
-        public UpdateOverdriveAchievedMessage(BattlePartyMember partyMember)
+        public UpdateOverdriveAchievedMessage(PartyMember partyMember)
         {
             PartyMember = partyMember;
         }

--- a/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
@@ -1,149 +1,25 @@
-using System.Collections.Generic;
 using System.Linq;
 using Jrpg.Core;
-using Jrpg.Runtime.DataClasses.PartyData;
 using Jrpg.Runtime.Systems.EquipmentData;
-using TMPro;
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 namespace Jrpg.Runtime.Battle.UI
 {
-    internal sealed class AttackPanelController : MonoBehaviour
+    internal sealed class AttackPanelController : OptionsPanelController
     {
-        [Header("UI")]
-        [SerializeField] 
-        private TextMeshProUGUI pageNumberText;
-
-        [SerializeField] 
-        private GameObject optionsContainer;
-
-        [SerializeField] 
-        private CanvasGroup canvasGroup;
-
-        [SerializeField] 
-        private AttackOption attackOptionPrefab;
-
         [SerializeField] 
         private Option overdriveOptionPrefab;
 
-        [Header("Buttons")] 
-        [SerializeField] 
-        private InputActionReference attackButton;
-
-        [SerializeField] 
-        private InputActionReference incrementOptionIndexButton;
-        
-        [SerializeField]
-        private InputActionReference decrementOptionIndexButton;
-
-        [SerializeField] 
-        private List<InputActionReference> otherButtons;
-
-        [Header("Attacks")] 
-        [SerializeField] 
-        private List<Option> attackOptions;
-
-        private List<GameObject> totalOptions;
-        
-        private BattlePartyMember partyMember;
-        
-        private int pageIndex = 0;
-        private int optionIndex = 0;
-
-        private bool commandsEnabled;
-
         private IEquipmentDataSystem equipmentDataSystem;
 
-        private void Awake()
+        protected override void Awake()
         {
+            base.Awake();
+            
             equipmentDataSystem = GameManager.GetSystem<IEquipmentDataSystem>();
         }
 
-        private void OnEnable()
-        {
-            AddListeners();
-        }
-
-        private void OnDisable()
-        {
-            RemoveListeners();
-        }
-
-        private void OnIncrementOptionIndexButtonPressed(InputAction.CallbackContext context)
-        {
-            optionIndex -= 1;
-            CheckOptionIndex();
-            HighlightCurrentOption();
-        }
-        
-        private void OnDecrementOptionIndexButtonPressed(InputAction.CallbackContext context)
-        {
-            optionIndex += 1;
-            CheckOptionIndex();
-            HighlightCurrentOption();
-        }
-
-        private void CheckOptionIndex()
-        {
-            if (optionIndex > attackOptions.Count - 1)
-            {
-                optionIndex = 0;
-            }
-
-            if (optionIndex < 0)
-            {
-                optionIndex = attackOptions.Count - 1;
-            }
-        }
-
-        private void OnAttackButtonPressed(InputAction.CallbackContext context)
-        {
-            if (!canvasGroup.interactable && commandsEnabled)
-            {
-                GameManager.Publish(new PartyMemberSelectionModeEnabledMessage());
-                SetPanelActive(true);
-                return;
-            }
-            
-            //select attack, switch to targeting panel?
-        }
-
-        private void OnAnyOtherFaceButtonPressed(InputAction.CallbackContext context)
-        {
-            if (canvasGroup.interactable && commandsEnabled)
-            {
-                SetPanelActive(false);
-            }
-        }
-
-        private void SetPanelActive(bool isActive)
-        {
-            canvasGroup.alpha = isActive ? 1f : 0f;
-            canvasGroup.interactable = isActive;
-            canvasGroup.blocksRaycasts = isActive;
-        }
-
-        private void ResetPanel()
-        {
-            pageIndex = 0;
-            pageNumberText.text = (pageIndex + 1).ToString();
-
-            if (attackOptions == null)
-            {
-                return;
-            }
-
-            foreach (var attack in attackOptions)
-            {
-                var attackObject = attack.gameObject;
-                Destroy(attackObject);
-            }
-            
-            attackOptions.Clear();
-        }
-
-        private void InitializePanel(PartyMember partyMember)
+        protected override void InitializePanelOptions()
         {
             var listAttacks = partyMember.ActiveWeapons.LeftHandWeapon.GemSlots
                 .Concat(partyMember.ActiveWeapons.RightHandWeapon.GemSlots);
@@ -156,9 +32,9 @@ namespace Jrpg.Runtime.Battle.UI
                 }
 
                 var gem = equipmentDataSystem.GetGem(attack);
-                var option = Instantiate(attackOptionPrefab, optionsContainer.transform);
+                var option = Instantiate(optionPrefab, optionsContainer.transform);
                     option.InitializeAttackOption(gem.GemName, gem);
-                    attackOptions.Add(option);
+                    listOptions.Add(option);
             }
 
             if (!partyMember.OverdriveAchieved)
@@ -166,27 +42,10 @@ namespace Jrpg.Runtime.Battle.UI
                 return;
             }
             var overdrive = Instantiate(overdriveOptionPrefab, optionsContainer.transform);
-            attackOptions.Add(overdrive);
+            listOptions.Add(overdrive);
         }
 
-        private void HighlightCurrentOption()
-        {
-            foreach (var attack in attackOptions)
-            {
-                attack.SetSelected(false);
-            }
-            
-            attackOptions[optionIndex].SetSelected(true);
-        }
 
-        private void OnPartyMemberSelected(PartyMemberSelectedMessage message)
-        {
-            partyMember = message.PartyMember;
-            commandsEnabled = true;
-            ResetPanel();
-            InitializePanel(message.PartyMember.GetEntityData());
-            HighlightCurrentOption();
-        }
 
         private void OnUpdateOverdriveAchievedMessage(UpdateOverdriveAchievedMessage message)
         {
@@ -196,49 +55,23 @@ namespace Jrpg.Runtime.Battle.UI
             }
             
             var overdrive = Instantiate(overdriveOptionPrefab, optionsContainer.transform);
-            attackOptions.Add(overdrive);
+            listOptions.Add(overdrive);
         }
 
-        private void AddListeners()
+        protected override void AddListeners()
         {
+            base.AddListeners();
+            
             GameManager.AddListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
             GameManager.AddListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
-            
-            attackButton.action.performed += OnAttackButtonPressed;
-            attackButton.action.Enable();
-            
-            incrementOptionIndexButton.action.performed += OnIncrementOptionIndexButtonPressed;
-            incrementOptionIndexButton.action.Enable();
-            
-            decrementOptionIndexButton.action.performed += OnDecrementOptionIndexButtonPressed;
-            decrementOptionIndexButton.action.Enable();
-
-            foreach (var button in otherButtons)
-            {
-                button.action.performed += OnAnyOtherFaceButtonPressed;
-                button.action.Enable();
-            }
         }
 
-        private void RemoveListeners()
+        protected override void RemoveListeners()
         {
+            base.RemoveListeners();
+            
             GameManager.RemoveListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
             GameManager.RemoveListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
-            
-            attackButton.action.performed -= OnAttackButtonPressed;
-            attackButton.action.Disable();
-            
-            incrementOptionIndexButton.action.performed -= OnIncrementOptionIndexButtonPressed;
-            incrementOptionIndexButton.action.Disable();
-            
-            decrementOptionIndexButton.action.performed -= OnDecrementOptionIndexButtonPressed;
-            decrementOptionIndexButton.action.Disable();
-
-            foreach (var button in otherButtons)
-            {
-                button.action.performed -= OnAnyOtherFaceButtonPressed;
-                button.action.Disable();
-            }
         }
     }
 }

--- a/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
@@ -62,7 +62,6 @@ namespace Jrpg.Runtime.Battle.UI
         {
             base.AddListeners();
             
-            GameManager.AddListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
             GameManager.AddListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
         }
 
@@ -70,7 +69,6 @@ namespace Jrpg.Runtime.Battle.UI
         {
             base.RemoveListeners();
             
-            GameManager.RemoveListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
             GameManager.RemoveListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
         }
     }

--- a/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
@@ -162,6 +162,8 @@ namespace Jrpg.Runtime.Battle.UI
 
         protected virtual void AddListeners()
         {
+            GameManager.AddListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
+            
             optionFaceButton.action.performed += OnOptionFaceButtonPressed;
             optionFaceButton.action.Enable();
             
@@ -180,6 +182,8 @@ namespace Jrpg.Runtime.Battle.UI
 
         protected virtual void RemoveListeners()
         {
+            GameManager.RemoveListener<PartyMemberSelectedMessage>(OnPartyMemberSelected);
+            
             optionFaceButton.action.performed -= OnOptionFaceButtonPressed;
             optionFaceButton.action.Disable();
             

--- a/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using Jrpg.Core;
+using Jrpg.Runtime.DataClasses.PartyData;
+using TMPro;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Jrpg.Runtime.Battle.UI
+{
+    internal class OptionsPanelController : MonoBehaviour
+    {
+        [Header("UI")]
+        [SerializeField] 
+        protected TextMeshProUGUI pageNumberText;
+
+        [SerializeField] 
+        protected GameObject optionsContainer;
+
+        [SerializeField] 
+        protected CanvasGroup canvasGroup;
+
+        [SerializeField] 
+        protected AttackOption optionPrefab;
+        
+        [Header("Buttons")] 
+        [SerializeField] 
+        protected InputActionReference optionFaceButton;
+
+        [SerializeField] 
+        protected InputActionReference incrementOptionIndexButton;
+        
+        [SerializeField]
+        protected InputActionReference decrementOptionIndexButton;
+
+        [SerializeField] 
+        protected List<InputActionReference> otherFaceButtons;
+        
+        [Header("Attacks")] 
+        [SerializeField] 
+        protected List<Option> listOptions;
+
+        protected List<GameObject> totalOptions;
+        
+        protected PartyMember partyMember;
+
+        private int pageIndex = 0;
+        private int optionIndex = 0;
+        private bool commandsEnabled;
+
+        protected virtual void Awake()
+        {
+            SetPanelActive(false);
+        }
+
+        protected virtual void OnEnable()
+        {
+            AddListeners();
+        }
+
+        protected virtual void OnDisable()
+        {
+            RemoveListeners();
+        }
+
+        private void OnIncrementOptionIndexButtonPressed(InputAction.CallbackContext context)
+        {
+            optionIndex -= 1;
+            CheckOptionIndex();
+            HighlightCurrentOption();
+        }
+
+        private void OnDecrementOptionIndexButtonPressed(InputAction.CallbackContext context)
+        {
+            optionIndex += 1;
+            CheckOptionIndex();
+            HighlightCurrentOption();
+        }
+
+        private void CheckOptionIndex()
+        {
+            if (optionIndex > listOptions.Count - 1)
+            {
+                optionIndex = 0;
+            }
+
+            if (optionIndex < 0)
+            {
+                optionIndex = listOptions.Count - 1;
+            }
+        }
+
+        private void OnOptionFaceButtonPressed(InputAction.CallbackContext context)
+        {
+            if (!canvasGroup.interactable && commandsEnabled)
+            {
+                GameManager.Publish(new PartyMemberSelectionModeEnabledMessage());
+                SetPanelActive(true);
+                return;
+            }
+            
+            //select attack, switch to targeting panel?
+        }
+
+        private void OnAnyOtherFaceButtonPressed(InputAction.CallbackContext context)
+        {
+            if (canvasGroup.interactable && commandsEnabled)
+            {
+                SetPanelActive(false);
+            }
+        }
+
+        private void SetPanelActive(bool isActive)
+        {
+            canvasGroup.alpha = isActive ? 1f : 0f;
+            canvasGroup.interactable = isActive;
+            canvasGroup.blocksRaycasts = isActive;
+        }
+
+        private void ResetPanel()
+        {
+            optionIndex = 0;
+            pageIndex = 0;
+            pageNumberText.text = (pageIndex + 1).ToString();
+
+            if (listOptions == null)
+            {
+                return;
+            }
+
+            foreach (var attack in listOptions)
+            {
+                var attackObject = attack.gameObject;
+                Destroy(attackObject);
+            }
+            
+            listOptions.Clear();
+        }
+
+        private void HighlightCurrentOption()
+        {
+            foreach (var attack in listOptions)
+            {
+                attack.SetSelected(false);
+            }
+            
+            listOptions[optionIndex].SetSelected(true);
+        }
+
+        protected void OnPartyMemberSelected(PartyMemberSelectedMessage message)
+        {
+            partyMember = message.PartyMember.GetEntityData();
+            commandsEnabled = true;
+            ResetPanel();
+            InitializePanelOptions();
+            HighlightCurrentOption();
+        }
+
+        protected virtual void InitializePanelOptions()
+        {
+        }
+
+        protected virtual void AddListeners()
+        {
+            optionFaceButton.action.performed += OnOptionFaceButtonPressed;
+            optionFaceButton.action.Enable();
+            
+            incrementOptionIndexButton.action.performed += OnIncrementOptionIndexButtonPressed;
+            incrementOptionIndexButton.action.Enable();
+            
+            decrementOptionIndexButton.action.performed += OnDecrementOptionIndexButtonPressed;
+            decrementOptionIndexButton.action.Enable();
+
+            foreach (var button in otherFaceButtons)
+            {
+                button.action.performed += OnAnyOtherFaceButtonPressed;
+                button.action.Enable();
+            }
+        }
+
+        protected virtual void RemoveListeners()
+        {
+            optionFaceButton.action.performed -= OnOptionFaceButtonPressed;
+            optionFaceButton.action.Disable();
+            
+            incrementOptionIndexButton.action.performed -= OnIncrementOptionIndexButtonPressed;
+            incrementOptionIndexButton.action.Disable();
+            
+            decrementOptionIndexButton.action.performed -= OnDecrementOptionIndexButtonPressed;
+            decrementOptionIndexButton.action.Disable();
+
+            foreach (var button in otherFaceButtons)
+            {
+                button.action.performed -= OnAnyOtherFaceButtonPressed;
+                button.action.Disable();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs.meta
+++ b/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6b480e0908ad460b83f59dd5f6cb6740
+timeCreated: 1683346736


### PR DESCRIPTION
**Changes:**
- Created new class, `OptionsPanelController`, which contains many `base` methods in common with most option panels that can be called and overriden by more specific panel controllers that inherit from this script.
- `AttackPanelController` now inherits from `OptionsPanelController`.
- Any fields that previous referenced the work `attack` were changed to the more generic term, `option`.
- Also fixed a bug regarding a `ArgumentOutOfRangeException` when cycling through party members on the battlefield by making sure that the `optionIndex` gets set to `0` during `ResetPanel`.

**For More Info See:**
closes #26 
resolves #27 
