### PR TITLE
Magic panel Instantiates Magic Options

### DIFF
--- a/Assets/Prefabs/Battlescreen/UI/Commands/MagicOption.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/MagicOption.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8561278860604449358}
   - component: {fileID: 6915859367530590872}
   - component: {fileID: 2824276566863469419}
+  - component: {fileID: 5887640623992391518}
   m_Layer: 5
   m_Name: MagicOption
   m_TagString: Untagged
@@ -79,6 +80,24 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5887640623992391518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469814672520230583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a6129eb98534476afd377e5bbfeb918, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprite: {fileID: 1953630256502825529}
+  nameText: {fileID: 18055993772774071}
+  backgroundImage: {fileID: 2824276566863469419}
+  normalColor: {r: 0.16862746, g: 0.16862746, b: 0.16862746, a: 0.5254902}
+  highlightColor: {r: 0.5294118, g: 0.5294118, b: 0.5294118, a: 0.5254902}
+  optionCostText: {fileID: 3431375667021433584}
 --- !u!1 &3330658121843837502
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Battlescreen/UI/Commands/MagicPanel.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/MagicPanel.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4170392721842493988}
   - component: {fileID: 4308050075614435397}
   - component: {fileID: 3611947588372340913}
+  - component: {fileID: 3515268453445938366}
   m_Layer: 5
   m_Name: MagicPanel
   m_TagString: Untagged
@@ -60,6 +61,30 @@ CanvasGroup:
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
+--- !u!114 &3515268453445938366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1174696681332865720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5041d93632ef461ca802387b8a58bdc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pageNumberText: {fileID: 8374011512357220699}
+  optionsContainer: {fileID: 6986135688913049687}
+  canvasGroup: {fileID: 3611947588372340913}
+  optionPrefab: {fileID: 5887640623992391518, guid: e7cfeb9a0b358b54c8235c5a16aa676c, type: 3}
+  optionFaceButton: {fileID: 4557948942953932904, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  incrementOptionIndexButton: {fileID: 2228769679593563241, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  decrementOptionIndexButton: {fileID: 401235817350929183, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  otherFaceButtons:
+  - {fileID: -4256021037253564534, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  - {fileID: 256541589240922355, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  - {fileID: -404835749428702899, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
+  listOptions: []
 --- !u!1001 &390309596541218594
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -160,6 +185,11 @@ PrefabInstance:
 --- !u!224 &4850564777911993298 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5060359836147166448, guid: 34df7f873fb37ba47bf4fef52a29f114, type: 3}
+  m_PrefabInstance: {fileID: 390309596541218594}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6986135688913049687 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7320906753499248501, guid: 34df7f873fb37ba47bf4fef52a29f114, type: 3}
   m_PrefabInstance: {fileID: 390309596541218594}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5864353648601664147
@@ -264,3 +294,14 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2689820544312789671, guid: 226fa97c1d621eb42a809fb6595ce974, type: 3}
   m_PrefabInstance: {fileID: 5864353648601664147}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8374011512357220699 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2689820545788050376, guid: 226fa97c1d621eb42a809fb6595ce974, type: 3}
+  m_PrefabInstance: {fileID: 5864353648601664147}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Databases/charms.json
+++ b/Assets/Resources/Databases/charms.json
@@ -1,21 +1,21 @@
 {
   "charms": [
     {
-      "charmName": "Healing Touch",
+      "name": "Healing Touch",
       "charmAttack": 0,
       "charmHeal": 75,
       "charmStatusEffect": "",
       "charmStatusEffectChance": 0.0
     },
     {
-      "charmName": "Flame Strike",
+      "name": "Flame Strike",
       "charmAttack": 50,
       "charmHeal": 0,
       "charmStatusEffect": "",
       "charmStatusEffectChance": 0.0
     },
     {
-      "charmName": "Magical Slap",
+      "name": "Magical Slap",
       "charmAttack": 25,
       "charmHeal": 0,
       "charmStatusEffect": "Concussed",

--- a/Assets/Resources/Databases/gems.json
+++ b/Assets/Resources/Databases/gems.json
@@ -2,70 +2,70 @@
     "gems": [
       
       {
-        "gemName": "Stab",
+        "name": "Stab",
         "gemType": "Sword",
         "gemAttack": 15,
         "gemStatusEffect": "",
         "gemStatusEffectChance": 0
       },
       {
-        "gemName": "Slash",
+        "name": "Slash",
         "gemType": "Sword",
         "gemAttack": 20,
         "gemStatusEffect": "",
         "gemStatusEffectChance": 0
       },
       {
-        "gemName": "Scattershot",
+        "name": "Scattershot",
         "gemType": "Gun",
         "gemAttack": 15,
         "gemStatusEffect": "",
         "gemStatusEffectChance": 0
       },
       {
-        "gemName": "Blindside",
+        "name": "Blindside",
         "gemType": "Gun",
         "gemAttack": 23,
         "gemStatusEffect": "Blurred Vision",
         "gemStatusEffectChance": 0.75
       },
       {
-        "gemName": "Sleepy Time",
+        "name": "Sleepy Time",
         "gemType": "Misc",
         "gemAttack": 2,
         "gemStatusEffect": "Sleep",
         "gemStatusEffectChance": 0.75
       },
       {
-        "gemName": "Poison Slap",
+        "name": "Poison Slap",
         "gemType": "Misc",
         "gemAttack": 5,
         "gemStatusEffect": "Poison",
         "gemStatusEffectChance": 0.75
       },
       {
-        "gemName": "Bolt",
+        "name": "Bolt",
         "gemType": "Wand",
         "gemAttack": 10,
         "gemStatusEffect": "Stunned",
         "gemStatusEffectChance": 0.10
       },
       {
-        "gemName": "Ember",
+        "name": "Ember",
         "gemType": "Wand",
         "gemAttack": 12,
         "gemStatusEffect": " ",
         "gemStatusEffectChance": 0.0
       },
       {
-        "gemName": "Fire Rain",
+        "name": "Fire Rain",
         "gemType": "Bow",
         "gemAttack": 15,
         "gemStatusEffect": " ",
         "gemStatusEffectChance": 0.0
       },
       {
-        "gemName": "Ice Rain",
+        "name": "Ice Rain",
         "gemType": "Bow",
         "gemAttack": 12,
         "gemStatusEffect": " ",

--- a/Assets/Resources/Databases/items.json
+++ b/Assets/Resources/Databases/items.json
@@ -1,7 +1,7 @@
 {
   "items" : [
     {
-      "itemName" : "Lite Potion",
+      "name" : "Lite Potion",
       "description" : "Light and fruity.",
       "itemMode" : "Health",
       "itemAmount" : "25",
@@ -9,7 +9,7 @@
       "itemStatusEffectChance" : 0
     },
     {
-      "itemName" : "Lite Ether",
+      "name" : "Lite Ether",
       "description" : "It tastes like cough medicine...",
       "itemMode" : "SP",
       "itemAmount" : "15",

--- a/Assets/Resources/Databases/necklaces.json
+++ b/Assets/Resources/Databases/necklaces.json
@@ -2,22 +2,22 @@
   "necklaces": [
 
     {
-      "necklaceName": "Nostalgic Locket",
+      "name": "Nostalgic Locket",
       "description": "Contains a picture of a childhood friend.",
       "numCharmSlots": 4
     },
     {
-      "necklaceName": "Stained Silver Chain",
+      "name": "Stained Silver Chain",
       "description": "A thin silver chain that has oxidized.",
       "numCharmSlots": 1
     },
     {
-      "necklaceName": "Simple Gold Chain",
+      "name": "Simple Gold Chain",
       "description": "A thin gold chain.",
       "numCharmSlots": 2
     },
     {
-      "necklaceName": "Stranger's Locket",
+      "name": "Stranger's Locket",
       "description": "This isn't yours. Perhaps find its owner?",
       "numCharmSlots": 5
     }

--- a/Assets/Resources/Databases/overdrives.json
+++ b/Assets/Resources/Databases/overdrives.json
@@ -1,28 +1,28 @@
 {
   "overdrives": [
     {
-      "overdriveName" : "XR57",
+      "name" : "XR57",
       "description" : "Strike faster than the speed of light.",
       "partyMember" : "PartyMember000",
       "levelAcquired" : "7",
       "overdriveAttack" : "150"
     },
     {
-      "overdriveName" : "Trance",
+      "name" : "Trance",
       "description" : "Go into a trance and do more damage.",
       "partyMember" : "PartyMember001",
       "levelAcquired" : "10",
       "overdriveAttack" : "200",
     },
     {
-      "overdriveName" : "Rage",
+      "name" : "Rage",
       "description" : "Rage and do more damage.",
       "partyMember" : "PartyMember002",
       "levelAcquired" : "15",
       "overdriveAttack" : "250"
     },
     {
-      "overdriveName" : "Berserk",
+      "name" : "Berserk",
       "description" : "Enter into a berserker state and do more damage.",
       "partyMember" : "PartyMember003",
       "levelAcquired" : "20",

--- a/Assets/Resources/Databases/weapons.json
+++ b/Assets/Resources/Databases/weapons.json
@@ -2,7 +2,7 @@
   "weapons": [
     
     {
-      "weaponName": "Rusty Swashbuckler",
+      "name": "Rusty Swashbuckler",
       "weaponType": "Sword",
       "weaponStance": "one-hand",
       "weaponAttack": 15,
@@ -11,7 +11,7 @@
       "weaponGemSlots": 2
     },
     {
-      "weaponName": "Weathered Shotgun",
+      "name": "Weathered Shotgun",
       "weaponType": "Gun",
       "weaponStance": "one-hand",
       "weaponAttack": 20,
@@ -20,7 +20,7 @@
       "weaponGemSlots": 2
     },
     {
-      "weaponName": "Giant's Greatsword",
+      "name": "Giant's Greatsword",
       "weaponType": "Sword",
       "weaponStance": "two-hand",
       "weaponAttack": 40,
@@ -29,7 +29,7 @@
       "weaponGemSlots": 5
     },
     {
-      "weaponName": "Interesting Stick",
+      "name": "Interesting Stick",
       "weaponType": "Wand",
       "weaponStance": "one-hand",
       "weaponAttack": 5,
@@ -38,7 +38,7 @@
       "weaponGemSlots": 2
     },
     {
-      "weaponName": "Herb Sachet",
+      "name": "Herb Sachet",
       "weaponType": "Misc",
       "weaponStance": "one-hand",
       "weaponAttack": 1,
@@ -47,7 +47,7 @@
       "weaponGemSlots": 3
     },
     {
-      "weaponName": "Hero's Sword",
+      "name": "Hero's Sword",
       "weaponType": "Sword",
       "weaponStance": "one-hand",
       "weaponAttack": 25,
@@ -56,7 +56,7 @@
       "weaponGemSlots": 3
     },
     {
-      "weaponName": "Hero's Bow",
+      "name": "Hero's Bow",
       "weaponType": "Bow",
       "weaponStance": "one-hand",
       "weaponAttack": 25,

--- a/Assets/Scripts/Runtime/Battle/UI/AttackOption.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/AttackOption.cs
@@ -1,22 +1,6 @@
-using Jrpg.Runtime.DataClasses.EquipmentData;
-using TMPro;
-using UnityEngine;
-using UnityEngine.Serialization;
-using UnityEngine.UI;
-
 namespace Jrpg.Runtime.Battle.UI
 {
     internal sealed class AttackOption : Option
     {
-        [Header("Gem")] 
-        [SerializeField] private Gem assignedGem;
-
-        public Gem AssignedGem => assignedGem;
-
-        public void InitializeAttackOption(string attackName, Gem gem)
-        {
-            NameText.text = attackName;
-            assignedGem = gem;
-        }
     }
 }

--- a/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Jrpg.Core;
-using Jrpg.Runtime.Systems.EquipmentData;
+using Jrpg.Runtime.DataClasses.EquipmentData;
 using UnityEngine;
 
 namespace Jrpg.Runtime.Battle.UI
@@ -10,32 +10,12 @@ namespace Jrpg.Runtime.Battle.UI
         [SerializeField] 
         private Option overdriveOptionPrefab;
 
-        private IEquipmentDataSystem equipmentDataSystem;
-
-        protected override void Awake()
-        {
-            base.Awake();
-            
-            equipmentDataSystem = GameManager.GetSystem<IEquipmentDataSystem>();
-        }
-
-        protected override void InitializePanelOptions()
+        protected override void InitializePanel()
         {
             var listAttacks = partyMember.ActiveWeapons.LeftHandWeapon.GemSlots
                 .Concat(partyMember.ActiveWeapons.RightHandWeapon.GemSlots);
 
-            foreach (var attack in listAttacks)
-            {
-                if (string.IsNullOrWhiteSpace(attack) || string.IsNullOrEmpty(attack))
-                {
-                    continue;
-                }
-
-                var gem = equipmentDataSystem.GetGem(attack);
-                var option = Instantiate(optionPrefab, optionsContainer.transform);
-                    option.InitializeAttackOption(gem.GemName, gem);
-                    listOptions.Add(option);
-            }
+            InitializePanelOptions<Gem>(listAttacks);
 
             if (!partyMember.OverdriveAchieved)
             {
@@ -44,8 +24,6 @@ namespace Jrpg.Runtime.Battle.UI
             var overdrive = Instantiate(overdriveOptionPrefab, optionsContainer.transform);
             listOptions.Add(overdrive);
         }
-
-
 
         private void OnUpdateOverdriveAchievedMessage(UpdateOverdriveAchievedMessage message)
         {

--- a/Assets/Scripts/Runtime/Battle/UI/MagicOption.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/MagicOption.cs
@@ -1,0 +1,18 @@
+using Jrpg.Runtime.DataClasses.Bases;
+using TMPro;
+using UnityEngine;
+
+namespace Jrpg.Runtime.Battle.UI
+{
+    internal sealed class MagicOption : Option
+    {
+        [Header("Option Cost")] 
+        [SerializeField] private TMP_Text optionCostText;
+
+        public override void InitializeOption(string optionName, BaseEquipment equipment, int cost)
+        {
+            base.InitializeOption(optionName, equipment, cost);
+            optionCostText.text = cost.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Battle/UI/MagicOption.cs.meta
+++ b/Assets/Scripts/Runtime/Battle/UI/MagicOption.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6a6129eb98534476afd377e5bbfeb918
+timeCreated: 1683352973

--- a/Assets/Scripts/Runtime/Battle/UI/MagicPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/MagicPanelController.cs
@@ -1,0 +1,16 @@
+using Jrpg.Core;
+using Jrpg.Runtime.DataClasses.EquipmentData;
+using Jrpg.Runtime.Systems.EquipmentData;
+
+namespace Jrpg.Runtime.Battle.UI
+{
+    internal sealed class MagicPanelController : OptionsPanelController
+    {
+        protected override void InitializePanel()
+        {
+            var listMagic = partyMember.ActiveNecklace.Charms;
+
+            InitializePanelOptions<Charm>(listMagic);
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Battle/UI/MagicPanelController.cs.meta
+++ b/Assets/Scripts/Runtime/Battle/UI/MagicPanelController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5041d93632ef461ca802387b8a58bdc5
+timeCreated: 1683349899

--- a/Assets/Scripts/Runtime/Battle/UI/Option.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/Option.cs
@@ -1,3 +1,4 @@
+using Jrpg.Runtime.DataClasses.Bases;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -20,6 +21,11 @@ namespace Jrpg.Runtime.Battle.UI
         
         [SerializeField] private Color highlightColor = new Color(135, 135, 135, 134);
         
+        [Header("Equipment")] 
+        [SerializeField] private BaseEquipment assignedEquipment;
+
+        public BaseEquipment AssignedEquipment => assignedEquipment;
+        
         protected Image Sprite => sprite;
 
         protected TMP_Text NameText => nameText;
@@ -37,6 +43,24 @@ namespace Jrpg.Runtime.Battle.UI
         private void SetColor(Color color)
         {
             backgroundImage.color = color;
+        }
+
+        public virtual void InitializeOption(string optionName, BaseEquipment equipment)
+        {
+            NameText.text = optionName;
+            assignedEquipment = equipment;
+        }
+        
+        public virtual void InitializeOption(string optionName, BaseEquipment equipment, int cost)
+        {
+            NameText.text = optionName;
+            assignedEquipment = equipment;
+        }
+        
+        public virtual void InitializeOption(string optionName)
+        {
+            NameText.text = optionName;
+            assignedEquipment = null;
         }
     }
 }

--- a/Assets/Scripts/Runtime/DataClasses/Bases/BaseEquipment.cs
+++ b/Assets/Scripts/Runtime/DataClasses/Bases/BaseEquipment.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Jrpg.Runtime.DataClasses.Bases
+{
+    internal class BaseEquipment
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/Assets/Scripts/Runtime/DataClasses/Bases/BaseEquipment.cs.meta
+++ b/Assets/Scripts/Runtime/DataClasses/Bases/BaseEquipment.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d4f3eac38a004bccba5adfff74011bb5
+timeCreated: 1683350422

--- a/Assets/Scripts/Runtime/DataClasses/EquipmentData/Charms.cs
+++ b/Assets/Scripts/Runtime/DataClasses/EquipmentData/Charms.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
 namespace Jrpg.Runtime.DataClasses.EquipmentData
@@ -21,7 +22,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
         
         public Charm GetCharm(string charmName)
         {
-            foreach (var t in CharmsDatabase.Where(t => t.CharmName == charmName))
+            foreach (var t in CharmsDatabase.Where(t => t.Name == charmName))
             {
                 return t;
             }
@@ -33,11 +34,8 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
     /// <summary>
     /// An individual charm in the charms database.
     /// </summary>
-    internal sealed class Charm
+    internal sealed class Charm : BaseEquipment
     {
-        [JsonProperty("charmName")]
-        public string CharmName { get; }
-        
         [JsonProperty("charmAttack")]
         public int CharmAttack { get; }
         
@@ -51,14 +49,14 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
         public float CharmStatusEffectChance { get; }
 
         public Charm(
-            [JsonProperty("charmName")] string charmName,
+            [JsonProperty("name")] string charmName,
             [JsonProperty("charmAttack")] int charmAttack,
             [JsonProperty("charmHeal")] int charmHeal,
             [JsonProperty("charmStatusEffect")] string charmStatusEffect,
             [JsonProperty("charmStatusEffectChance")] float charmStatusEffectChance
         )
         {
-            CharmName = charmName;
+            Name = charmName;
             CharmAttack = charmAttack;
             CharmHeal = charmHeal;
             CharmStatusEffect = charmStatusEffect;

--- a/Assets/Scripts/Runtime/DataClasses/EquipmentData/Gems.cs
+++ b/Assets/Scripts/Runtime/DataClasses/EquipmentData/Gems.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
 namespace Jrpg.Runtime.DataClasses.EquipmentData
@@ -21,7 +22,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
         
         public Gem GetGem(string gemName)
         {
-            foreach (var t in GemsDatabase.Where(t => t.GemName == gemName))
+            foreach (var t in GemsDatabase.Where(t => t.Name == gemName))
             {
                 return t;
             }
@@ -33,11 +34,8 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
     /// <summary>
     /// An individual gem in the gems database.
     /// </summary>
-    internal sealed class Gem
+    internal sealed class Gem : BaseEquipment
     {
-        [JsonProperty("gemName")]
-        public string GemName { get; }
-        
         [JsonProperty("gemType")]
         public string GemType { get; }
         
@@ -51,14 +49,14 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
         public float GemStatusEffectChance { get; }
 
         public Gem(
-            [JsonProperty("gemName")] string gemName,
+            [JsonProperty("name")] string gemName,
             [JsonProperty("gemType")] string gemType,
             [JsonProperty("gemAttack")] int gemAttack,
             [JsonProperty("gemStatusEffect")] string gemStatusEffect,
             [JsonProperty("gemStatusEffectChance")] float gemStatusEffectChance
         )
         {
-            GemName = gemName;
+            Name = gemName;
             GemType = gemType;
             GemAttack = gemAttack;
             GemStatusEffect = gemStatusEffect;

--- a/Assets/Scripts/Runtime/DataClasses/EquipmentData/Necklaces.cs
+++ b/Assets/Scripts/Runtime/DataClasses/EquipmentData/Necklaces.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
 namespace Jrpg.Runtime.DataClasses.EquipmentData
@@ -21,7 +22,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
         
         public Necklace GetNecklace(string necklaceName)
         {
-            foreach (var t in NecklacesDatabase.Where(t => t.NecklaceName == necklaceName))
+            foreach (var t in NecklacesDatabase.Where(t => t.Name == necklaceName))
             {
                 return t;
             }
@@ -33,11 +34,8 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
     /// <summary>
     /// An individual necklace in the necklaces database.
     /// </summary>
-    internal sealed class Necklace
+    internal sealed class Necklace : BaseEquipment
     {
-        [JsonProperty("necklaceName")]
-        public string NecklaceName { get; }
-        
         [JsonProperty("necklaceType")]
         public int Description { get; }
         
@@ -50,7 +48,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
             [JsonProperty("gemAttack")] int numCharmSlots
         )
         {
-            NecklaceName = necklaceNameName;
+            Name = necklaceNameName;
             Description = description;
             NumCharmSlots = numCharmSlots;
         }

--- a/Assets/Scripts/Runtime/DataClasses/EquipmentData/Weapons.cs
+++ b/Assets/Scripts/Runtime/DataClasses/EquipmentData/Weapons.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
 namespace Jrpg.Runtime.DataClasses.EquipmentData
@@ -21,7 +22,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
 
         public Weapon GetWeapon(string weaponName)
         {
-            foreach (var t in WeaponsDatabase.Where(t => t.WeaponName == weaponName))
+            foreach (var t in WeaponsDatabase.Where(t => t.Name == weaponName))
             {
                 return t;
             }
@@ -33,11 +34,8 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
     /// <summary>
     /// An individual weapon in the weapons database.
     /// </summary>
-    internal sealed class Weapon
+    internal sealed class Weapon : BaseEquipment
     {
-        [JsonProperty("weaponName")]
-        public string WeaponName { get; }
-        
         [JsonProperty("weaponType")]
         public string WeaponType { get; }
         
@@ -67,7 +65,7 @@ namespace Jrpg.Runtime.DataClasses.EquipmentData
             
         )
         {
-            WeaponName = weaponName;
+            Name = weaponName;
             WeaponType = weaponType;
             WeaponStance = weaponStance;
             WeaponAttack = weaponAttack;

--- a/Assets/Scripts/Runtime/Systems/EquipmentData/EquipmentDataSystem.cs
+++ b/Assets/Scripts/Runtime/Systems/EquipmentData/EquipmentDataSystem.cs
@@ -1,5 +1,5 @@
+using Jrpg.Runtime.DataClasses.Bases;
 using Jrpg.Runtime.DataClasses.EquipmentData;
-using Jrpg.Runtime.DataClasses.ItemData;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -33,24 +33,48 @@ namespace Jrpg.Runtime.Systems.EquipmentData
             LoadData();
         }
         
-        public Weapon GetWeapon(string weaponName)
+        public Weapon GetWeaponByName(string weaponName)
         {
             return weaponsData.GetWeapon(weaponName);
         }
         
-        public Charm GetCharm(string charmName)
+        public Charm GetCharmByName(string charmName)
         {
             return charmsData.GetCharm(charmName);
         }
         
-        public Gem GetGem(string gemName)
+        public Gem GetGemByName(string gemName)
         {
             return gemsData.GetGem(gemName);
         }
 
-        public Necklace GetNecklace(string necklaceName)
+        public Necklace GetNecklaceByName(string necklaceName)
         {
             return necklacesData.GetNecklace(necklaceName);
+        }
+
+        public BaseEquipment GetEquipmentDataByName<T>(string equipmentName)
+        {
+            if (typeof(T) == typeof(Weapon))
+            {
+                return GetWeaponByName(equipmentName);
+            }
+            else if (typeof(T) == typeof(Charm))
+            {
+                return GetCharmByName(equipmentName);
+            }
+            else if (typeof(T) == typeof(Gem))
+            {
+                return GetGemByName(equipmentName);
+            }
+            else if (typeof(T) == typeof(Necklace))
+            {
+                return GetNecklaceByName(equipmentName);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         private void LoadData()

--- a/Assets/Scripts/Runtime/Systems/EquipmentData/IEquipmentDataSystem.cs
+++ b/Assets/Scripts/Runtime/Systems/EquipmentData/IEquipmentDataSystem.cs
@@ -1,29 +1,34 @@
 using Jrpg.Core;
+using Jrpg.Runtime.DataClasses.Bases;
 using Jrpg.Runtime.DataClasses.EquipmentData;
-using Jrpg.Runtime.DataClasses.ItemData;
 
 namespace Jrpg.Runtime.Systems.EquipmentData
 {
     internal interface IEquipmentDataSystem : ISystem
     {
         /// <summary>
-        /// Gets a weapon from the weapons database using <param name="weaponName"></param>.
+        /// Gets a weapon from the weapons database using <paramref name="weaponName"/>.
         /// </summary>
-        public Weapon GetWeapon(string weaponName);
+        public Weapon GetWeaponByName(string weaponName);
         
         /// <summary>
-        /// Gets a charm from the charms database using <param name="charmName"></param>.
+        /// Gets a charm from the charms database using <paramref name="charmName"/>.
         /// </summary>
-        public Charm GetCharm(string charmName);
+        public Charm GetCharmByName(string charmName);
         
         /// <summary>
-        /// Gets a gem from the gems database using <param name="gemName"></param>.
+        /// Gets a gem from the gems database using <paramref name="gemName"/>.
         /// </summary>
-        public Gem GetGem(string gemName);
+        public Gem GetGemByName(string gemName);
         
         /// <summary>
-        /// Gets a necklace from the necklaces database using <param name="necklaceName"></param>.
+        /// Gets a necklace from the necklaces database using <paramref name="necklaceName"/>.
         /// </summary>
-        public Necklace GetNecklace(string necklaceName);
+        public Necklace GetNecklaceByName(string necklaceName);
+
+        /// <summary>
+        /// Gets a equipment from the equipment database using <paramref name="equipmentName"/>.
+        /// </summary>
+        public BaseEquipment GetEquipmentDataByName<T>(string equipmentName);
     }
 }


### PR DESCRIPTION
**Changes:**
- Created `MagicOption` class, which is used when instantiating options for the `MagicPanel`.
- Created `MagicPanelController`, which inherits from the `OptionsPanelController` and is used to help control the appearance of the `MagicPanel` and control when `MagicOptions` are instantiated or destroyed.
- Created a `BaseEquipment` class which is inherited by all equipment types and used for generic typing of different equipment from the various equipment databases.`
- Bare minimum refactoring of the json files associated with the names of `Charms`, `Gems`, `Necklaces`, and `Weapons`. Threw in refactoring of the same field for the json files associated with the names of `Items` and `Overdrives`. A full refactor will be needed in the future, towards the end of the base battle system being finished (see: #31).
- All `Get` methods for the `EquipmentDatabaseSystem` had the term `ByName` appended for clarity, as these methods get the equipment by `string` name.
- Added a `GetBaseEquipmentByName` method to the `EquipmentDatabaseSystem`, which uses generic typing to retrieve any equipment with underlying `Type` `BaseEquipment` from any equipment database.

**For More Info See:**
resolves #30 
closes #29 