### PR TITLE
Added Base Overdrive Panel Scripting

### DIFF
--- a/Assets/Prefabs/Battlescreen/UI/Commands/AttackMenuOverdriveOption.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/AttackMenuOverdriveOption.prefab
@@ -222,7 +222,7 @@ GameObject:
   - component: {fileID: 790597656574374862}
   - component: {fileID: 2579736652109538072}
   - component: {fileID: 6559168708406135531}
-  - component: {fileID: -1313844770527419125}
+  - component: {fileID: 6128760014969638905}
   m_Layer: 5
   m_Name: AttackMenuOverdriveOption
   m_TagString: Untagged
@@ -290,7 +290,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &-1313844770527419125
+--- !u!114 &6128760014969638905
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -299,7 +299,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7517304969578751799}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 175b1e0be4c1447bacb97763311ab6c1, type: 3}
+  m_Script: {fileID: 11500000, guid: ce01cbe885524d9c8c23220725199731, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   sprite: {fileID: 7434231309157987257}

--- a/Assets/Prefabs/Battlescreen/UI/Commands/AttackPanel.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/AttackPanel.prefab
@@ -85,7 +85,9 @@ MonoBehaviour:
   - {fileID: 256541589240922355, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   - {fileID: -404835749428702899, guid: bc7945ded6f281b4d900502588feb9f6, type: 3}
   listOptions: []
-  overdriveOptionPrefab: {fileID: -1313844770527419125, guid: 39071661c63fb3c469e78f6e450676ed, type: 3}
+  activeOverdriveOptionPrefab: {fileID: 6128760014969638905, guid: 39071661c63fb3c469e78f6e450676ed, type: 3}
+  overdriveOptionPrefab: {fileID: 212184361328472601, guid: c98d64dc4fe264c4488a9c79835f00bd, type: 3}
+  selectionMode: 0
 --- !u!1001 &4302823105299974583
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Battlescreen/UI/Commands/BattleCommandsPanel.prefab
+++ b/Assets/Prefabs/Battlescreen/UI/Commands/BattleCommandsPanel.prefab
@@ -35,7 +35,6 @@ RectTransform:
   - {fileID: 3297667734236535972}
   - {fileID: 2698205307763183132}
   - {fileID: 1473223144812915836}
-  - {fileID: 4455002920635158394}
   - {fileID: 7529008286721549941}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -234,128 +233,6 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2284516399597490842, guid: f10512fd51490c24da018ff64d98fe1d, type: 3}
   m_PrefabInstance: {fileID: 848307489515847398}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &893556581398757556
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 7806255959459580343}
-    m_Modifications:
-    - target: {fileID: 1736347703334547282, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_Name
-      value: LimitPanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 1736347703334547282, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 542.24
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 407.449
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -0.00024414
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -26.713497
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8855363868286122827, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8855363868286122827, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8855363868286122827, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8855363868286122827, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
---- !u!224 &4455002920635158394 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3582003775003758542, guid: b93c58dc67eaa95449c7da69381a8bd7, type: 3}
-  m_PrefabInstance: {fileID: 893556581398757556}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2058643637612811320
 PrefabInstance:
@@ -654,7 +531,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3276028133198137847, guid: 1bb1cde2fd3e082499768fd34610701b, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3276028133198137847, guid: 1bb1cde2fd3e082499768fd34610701b, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Resources/Databases/overdrives.json
+++ b/Assets/Resources/Databases/overdrives.json
@@ -11,21 +11,21 @@
       "name" : "Trance",
       "description" : "Go into a trance and do more damage.",
       "partyMember" : "PartyMember001",
-      "levelAcquired" : "10",
-      "overdriveAttack" : "200",
+      "levelAcquired" : "5",
+      "overdriveAttack" : "200"
     },
     {
       "name" : "Rage",
       "description" : "Rage and do more damage.",
       "partyMember" : "PartyMember002",
-      "levelAcquired" : "15",
+      "levelAcquired" : "7",
       "overdriveAttack" : "250"
     },
     {
       "name" : "Berserk",
       "description" : "Enter into a berserker state and do more damage.",
       "partyMember" : "PartyMember003",
-      "levelAcquired" : "20",
+      "levelAcquired" : "5",
       "overdriveAttack" : "300"
     }
   ]

--- a/Assets/Resources/GameManager.prefab
+++ b/Assets/Resources/GameManager.prefab
@@ -48,6 +48,7 @@ MonoBehaviour:
   charmsDataFile: {fileID: 4900000, guid: 620109ead483410790a85c339c040e44, type: 3}
   gemsDataFile: {fileID: 4900000, guid: 07bfb709c562433ab7062162451d2d82, type: 3}
   necklacesDataFile: {fileID: 4900000, guid: 49e890364c184ea98115abbd3a444889, type: 3}
+  overdrivesDataFile: {fileID: 4900000, guid: 8d6d9e799a584eb19f72ecc637d6436a, type: 3}
 --- !u!1 &2097759874764777842
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/SaveData/Default/DefaultSaveData.json
+++ b/Assets/Resources/SaveData/Default/DefaultSaveData.json
@@ -15,6 +15,7 @@
       "baseSpeed": 12,
       "positionOnField": "front",
       "handedness": "right",
+      "overdrives": ["XR57"],
       "equipment":
       {
         "hat": "Feathered Cap",
@@ -66,6 +67,7 @@
       "baseSpeed": 5,
       "positionOnField": "front",
       "handedness": "right",
+        "overdrives": ["Berserk"],
       "equipment":
       {
         "hat": "Fez",
@@ -117,6 +119,7 @@
       "baseSpeed": 18,
       "positionOnField": "back",
       "handedness": "left",
+      "overdrives": ["Trance"],
       "equipment":
       {
         "hat": "Silver Circlet",
@@ -168,6 +171,7 @@
       "baseSpeed": 15,
       "positionOnField": "front",
       "handedness": "left",
+      "overdrives": ["Rage"],
       "equipment": {
         "hat": "Elf Hat",
         "shirt": "Green Tunic",

--- a/Assets/Scripts/Runtime/Battle/Messages.cs
+++ b/Assets/Scripts/Runtime/Battle/Messages.cs
@@ -66,6 +66,10 @@ namespace Jrpg.Runtime.Battle
         }
     }
 
+    internal sealed class ActivateOverdriveMessage : IMessage
+    {
+    }
+
     internal sealed class BattleEntitySelectedMessage : IMessage
     {
         public BaseBattleEntity Entity { get; }

--- a/Assets/Scripts/Runtime/Battle/UI/ActivateOverdriveOption.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/ActivateOverdriveOption.cs
@@ -1,0 +1,13 @@
+using Jrpg.Core;
+using Jrpg.Runtime.Battle;
+
+namespace Jrpg.Runtime.Battle.UI
+{
+    internal sealed class ActivateOverdriveOption : Option
+    {
+        public override void OnClick()
+        {
+            GameManager.Publish(new ActivateOverdriveMessage());
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/Battle/UI/ActivateOverdriveOption.cs.meta
+++ b/Assets/Scripts/Runtime/Battle/UI/ActivateOverdriveOption.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce01cbe885524d9c8c23220725199731
+timeCreated: 1683852966

--- a/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/AttackPanelController.cs
@@ -1,16 +1,44 @@
 using System.Linq;
 using Jrpg.Core;
 using Jrpg.Runtime.DataClasses.EquipmentData;
+using Jrpg.Runtime.DataClasses.OverdriveData;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Jrpg.Runtime.Battle.UI
 {
     internal sealed class AttackPanelController : OptionsPanelController
     {
+        [Header("UI")]
+        [SerializeField] 
+        private Option activeOverdriveOptionPrefab;
+
         [SerializeField] 
         private Option overdriveOptionPrefab;
 
+        [SerializeField] private SelectionMode selectionMode = SelectionMode.Attack;
+
+        private enum SelectionMode
+        {
+            Attack,
+            Overdrive
+        }
+
         protected override void InitializePanel()
+        {
+            switch (selectionMode)
+            {
+                case SelectionMode.Attack:
+                    InitializeAttackPanel();
+                    break;
+                case SelectionMode.Overdrive:
+                    InitializeOverdrivePanel();
+                    break;
+            }
+            
+        }
+
+        private void InitializeAttackPanel()
         {
             var listAttacks = partyMember.ActiveWeapons.LeftHandWeapon.GemSlots
                 .Concat(partyMember.ActiveWeapons.RightHandWeapon.GemSlots);
@@ -21,8 +49,15 @@ namespace Jrpg.Runtime.Battle.UI
             {
                 return;
             }
-            var overdrive = Instantiate(overdriveOptionPrefab, optionsContainer.transform);
+            var overdrive = Instantiate(activeOverdriveOptionPrefab, optionsContainer.transform);
             listOptions.Add(overdrive);
+        }
+
+        private void InitializeOverdrivePanel()
+        {
+            var listOverdrives = partyMember.Overdrives;
+            
+            InitializePanelOptions<Overdrive>(listOverdrives, overdriveOptionPrefab);
         }
 
         private void OnUpdateOverdriveAchievedMessage(UpdateOverdriveAchievedMessage message)
@@ -32,8 +67,22 @@ namespace Jrpg.Runtime.Battle.UI
                 return;
             }
             
-            var overdrive = Instantiate(overdriveOptionPrefab, optionsContainer.transform);
+            var overdrive = Instantiate(activeOverdriveOptionPrefab, optionsContainer.transform);
             listOptions.Add(overdrive);
+        }
+        
+        private void OnActivateOverdriveMessageReceived(ActivateOverdriveMessage message)
+        {
+            selectionMode = SelectionMode.Overdrive;
+            
+            ResetPanel();
+            InitializePanel();
+        }
+
+        protected override void OnPartyMemberSelected(PartyMemberSelectedMessage message)
+        {
+            selectionMode = SelectionMode.Attack;
+            base.OnPartyMemberSelected(message);
         }
 
         protected override void AddListeners()
@@ -41,6 +90,7 @@ namespace Jrpg.Runtime.Battle.UI
             base.AddListeners();
             
             GameManager.AddListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
+            GameManager.AddListener<ActivateOverdriveMessage>(OnActivateOverdriveMessageReceived);
         }
 
         protected override void RemoveListeners()
@@ -48,6 +98,7 @@ namespace Jrpg.Runtime.Battle.UI
             base.RemoveListeners();
             
             GameManager.RemoveListener<UpdateOverdriveAchievedMessage>(OnUpdateOverdriveAchievedMessage);
+            GameManager.RemoveListener<ActivateOverdriveMessage>(OnActivateOverdriveMessageReceived);
         }
     }
 }

--- a/Assets/Scripts/Runtime/Battle/UI/Option.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/Option.cs
@@ -48,6 +48,11 @@ namespace Jrpg.Runtime.Battle.UI
             backgroundImage.color = color;
         }
 
+        public virtual void OnClick()
+        {
+            
+        }
+
         public virtual void InitializeOption(string optionName, BaseData data)
         {
             NameText.text = optionName;

--- a/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/OptionsPanelController.cs
@@ -110,8 +110,8 @@ namespace Jrpg.Runtime.Battle.UI
                 SetPanelActive(true);
                 return;
             }
-            
-            //select attack, switch to targeting panel?
+
+            listOptions[optionIndex].OnClick();
         }
 
         private void OnAnyOtherFaceButtonPressed(InputAction.CallbackContext context)
@@ -163,7 +163,7 @@ namespace Jrpg.Runtime.Battle.UI
             pageNumberText.text = (pageIndex + 1).ToString();
         }
 
-        protected void HighlightCurrentOption()
+        private void HighlightCurrentOption()
         {
             if (!listOptions.Any())
             {
@@ -205,6 +205,7 @@ namespace Jrpg.Runtime.Battle.UI
                 option.InitializeOption(itemData.Name, inventoryItem, itemData);
                 listOptions.Add(option);
             }
+            HighlightCurrentOption();
         }
 
         protected void InitializePanelOptions<T>(IEnumerable<string> tempListOptions)
@@ -221,6 +222,24 @@ namespace Jrpg.Runtime.Battle.UI
                     option.InitializeOption(optionData.Name, optionData);
                     listOptions.Add(option);
             }
+            HighlightCurrentOption();
+        }
+
+        protected void InitializePanelOptions<T>(IEnumerable<string> tempListOptions, Option otherOptionPrefab)
+        {
+            foreach (var tempOption in tempListOptions)
+            {
+                if(string.IsNullOrWhiteSpace(tempOption) || string.IsNullOrEmpty(tempOption))
+                {
+                    continue;
+                }
+
+                var optionData = equipmentDataSystem.GetEquipmentDataByName<T>(tempOption);
+                var option = Instantiate(otherOptionPrefab, optionsContainer.transform);
+                option.InitializeOption(optionData.Name, optionData);
+                listOptions.Add(option);
+            }
+            HighlightCurrentOption();
         }
 
         protected virtual void AddListeners()

--- a/Assets/Scripts/Runtime/Battle/UI/OverdriveOption.cs
+++ b/Assets/Scripts/Runtime/Battle/UI/OverdriveOption.cs
@@ -1,8 +1,5 @@
 using Jrpg.Runtime.DataClasses.OverdriveData;
-using TMPro;
 using UnityEngine;
-using UnityEngine.Serialization;
-using UnityEngine.UI;
 
 namespace Jrpg.Runtime.Battle.UI
 {
@@ -15,7 +12,7 @@ namespace Jrpg.Runtime.Battle.UI
         
         public void InitializeOverdriveOption(Overdrive overdrive)
         {
-            nameText.text = overdrive.OverdriveName;
+            nameText.text = overdrive.Name;
             assignedOverdrive = overdrive;
         }
     }

--- a/Assets/Scripts/Runtime/DataClasses/OverdriveData/Overdrives.cs
+++ b/Assets/Scripts/Runtime/DataClasses/OverdriveData/Overdrives.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
 namespace Jrpg.Runtime.DataClasses.OverdriveData
@@ -21,7 +22,7 @@ namespace Jrpg.Runtime.DataClasses.OverdriveData
         {
             foreach (var t in OverdrivesDatabase)
             {
-                if (t.OverdriveName == overdriveName)
+                if (t.Name == overdriveName)
                 {
                     return t;
                 }
@@ -34,11 +35,8 @@ namespace Jrpg.Runtime.DataClasses.OverdriveData
     /// <summary>
     /// An individual overdrive in the overdrives database.
     /// </summary>
-    internal sealed class Overdrive
+    internal sealed class Overdrive : BaseData
     {
-        [JsonProperty("overdriveName")]
-        public string OverdriveName { get; }
-        
         [JsonProperty("description")]
         public string Description { get; }
         
@@ -59,7 +57,7 @@ namespace Jrpg.Runtime.DataClasses.OverdriveData
             [JsonProperty("overdriveAttack")] int overdriveAttack
         )
         {
-            OverdriveName = overdriveName;
+            Name = overdriveName;
             Description = description;
             PartyMember = partyMember;
             LevelAcquired = levelAcquired;

--- a/Assets/Scripts/Runtime/DataClasses/PartyData/PartyMember.cs
+++ b/Assets/Scripts/Runtime/DataClasses/PartyData/PartyMember.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Jrpg.Runtime.DataClasses.Bases;
 using Newtonsoft.Json;
 
@@ -19,6 +20,9 @@ namespace Jrpg.Runtime.DataClasses.PartyData
 
         [JsonProperty("handedness")]
         public string Handedness { get; }
+        
+        [JsonProperty("overdrives")]
+        public List<string> Overdrives { get; }
 
         [JsonProperty("equipment")]
         public Equipment Equipment { get; }
@@ -48,6 +52,7 @@ namespace Jrpg.Runtime.DataClasses.PartyData
             [JsonProperty("baseSpeed")] int baseSpeed,
             [JsonProperty("positionOnField")] string positionOnField,
             [JsonProperty("handedness")] string handedness,
+            [JsonProperty("overdrives")] List<string> overdrives,
             [JsonProperty("equipment")] Equipment equipment, 
             [JsonProperty("activeRings")] ActiveRings activeRings,
             [JsonProperty("activeNecklace")] ActiveNecklace activeNecklace,
@@ -68,6 +73,7 @@ namespace Jrpg.Runtime.DataClasses.PartyData
             BaseSpeed = baseSpeed;
             PositionOnField = positionOnField;
             Handedness = handedness;
+            Overdrives = overdrives;
             Equipment = equipment;
             ActiveRings = activeRings;
             ActiveNecklace = activeNecklace;

--- a/Assets/Scripts/Runtime/Systems/EquipmentData/EquipmentDataSystem.cs
+++ b/Assets/Scripts/Runtime/Systems/EquipmentData/EquipmentDataSystem.cs
@@ -1,5 +1,6 @@
 using Jrpg.Runtime.DataClasses.Bases;
 using Jrpg.Runtime.DataClasses.EquipmentData;
+using Jrpg.Runtime.DataClasses.OverdriveData;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -22,11 +23,16 @@ namespace Jrpg.Runtime.Systems.EquipmentData
         [Header("Necklaces Data File")] 
         [SerializeField] 
         private TextAsset necklacesDataFile;
+        
+        [Header("Overdrives Data File")]
+        [SerializeField]
+        private TextAsset overdrivesDataFile;
 
         private Weapons weaponsData;
         private Charms charmsData;
         private Gems gemsData;
         private Necklaces necklacesData;
+        private Overdrives overdrivesData;
 
         private void Awake()
         {
@@ -52,6 +58,11 @@ namespace Jrpg.Runtime.Systems.EquipmentData
         {
             return necklacesData.GetNecklace(necklaceName);
         }
+        
+        public Overdrive GetOverdriveByName(string overdriveName)
+        {
+            return overdrivesData.GetOverdrive(overdriveName);
+        }
 
         public BaseData GetEquipmentDataByName<T>(string equipmentName)
         {
@@ -71,6 +82,10 @@ namespace Jrpg.Runtime.Systems.EquipmentData
             {
                 return GetNecklaceByName(equipmentName);
             }
+            else if (typeof(T) == typeof(Overdrive))
+            {
+                return GetOverdriveByName(equipmentName);
+            }
             else
             {
                 return null;
@@ -87,6 +102,8 @@ namespace Jrpg.Runtime.Systems.EquipmentData
                 .DeserializeObject<Gems>(gemsDataFile.text);
             necklacesData = JsonConvert
                 .DeserializeObject<Necklaces>(necklacesDataFile.text);
+            overdrivesData = JsonConvert
+                .DeserializeObject<Overdrives>(overdrivesDataFile.text);
         }
     }
 }


### PR DESCRIPTION
**Changes:**
- Removed `OverdrivePanel` prefab. Functionality has been subsumed into the `AttackPanel`.
- Added `ActivateOverdriveMessage` to `Messages` in the `Jrpg.Runtime.Battle` namespace.
- Added an `OnClick` method to the `Options` class, which can be overridden by any class inheriting from it.
- Added `ActivateOverdriveOption` script, which sends the `ActivateOverdriveMessage` at `OnClick`.
- Modified the database `overdrives` to use `name` instead of `overdriveName` for compatibility with `BaseData` type.
- Modified `overdrives` class to inherit from `BaseData`.
- Modified the party member information in `DefaultSaveData` so that there is a list of string for the party member's `overdrives`.
- Added `Overdrives` to `EquipmentDataSystem` for now. This will change in the future when `Systems` are refactored for the codebase.
- Changed `overdriveOptionPrefab` to `activateOverdriveOptionPrefab` in the `AttackPanelController` for clarity.
- Added a field for the `overdriveOptionPrefab` for instantiation of `OverdriveOption` when an `ActivateOverdriveMessage` is received by the `AttackPanelController`.
- Modified the `AttackPanelController` so that it has two states based on and `enum` called `SelectionMode`. The panel initializes with `selectionMode.Attack` as the default, and instantiates the `AttackOptions` with the `ActiveOverdriveOption` at the bottom. Upon receiving an `ActivateOverdriveMessage`, the panel switches to `selectionMode.Overdrive`, resets, and initializes the list of `Overdrives` available to the selected party member.

**For More Info See:**
closes #35 